### PR TITLE
Añade grunt-cli donde se debe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.10.5
 LABEL maintainer="Irene Cano Jerez"
 
 #creamos un usuario y una carpeta sobre la que tendrá permisos
-RUN adduser -S usuario && mkdir /idiomas && chown -R usuario /idiomas
+RUN adduser -S usuario && mkdir /idiomas && chown -R usuario /idiomas 
 
 #establecemos el directorio de trabajo
 WORKDIR /idiomas
@@ -13,7 +13,8 @@ WORKDIR /idiomas
 #permisos necesarios para el usuario e instalación de curl para poder descarganos después NVM y así instalar la versión de node que queramos, en este caso la 14.12.0
 RUN mkdir /idiomas/node_modules \
     && chown -R usuario /idiomas/node_modules \
-    && apk add --update nodejs npm
+    && apk add --update nodejs npm \
+    && npm i -g grunt-cli grunt-run
 
 #usuario sin privilegios
 USER usuario

--- a/package.json
+++ b/package.json
@@ -30,8 +30,5 @@
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0"
   },
-  "dependencies": {
-    "grunt-cli": "1.3.2",
-    "grunt-run": "^0.8.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Debéis usar los contenedores construidos para explorar qué se instala donde. En concreto, si pones "dependencies" no se va a instalar en ningún sitio global, sino en node_modules donde no estará accesible. Puedes añadir node_modules/.bin también al PATH, pero esta opción funciona y no incumple ninguna buena práctica.